### PR TITLE
Ajustando métodos getBalance e getFeed

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -84,14 +84,14 @@ export class Account {
   }
 
   public async getBalance(): Promise<number> {
-    const data = await this._context.http.graphql(
+    const { data } = await this._context.http.graphql(
       GqlOperations.QUERY_ACCOUNT_BALANCE
     );
     return data.viewer?.savingsAccount?.currentSavingsBalance?.netAmount;
   }
 
   public async getFeed(): Promise<AccountTransaction[]> {
-    const data = await this._context.http.graphql(
+    const { data } = await this._context.http.graphql(
       GqlOperations.QUERY_ACCOUNT_FEED
     );
     return data?.viewer?.savingsAccount?.feed;


### PR DESCRIPTION
Percebi que os métodos getBalance e getFeed estão utilizando a estrutura errada de retorno do graphQL e sempre retornam undefined por isso. Para consertar fiz as alterações abaixo:

getBalance de:
```typescript
  public async getBalance(): Promise<number> {
    const data = await this._context.http.graphql(
      GqlOperations.QUERY_ACCOUNT_BALANCE
    );
    return data.viewer?.savingsAccount?.currentSavingsBalance?.netAmount;
  }
```

para:

```typescript
  public async getBalance(): Promise<number> {
    const { data } = await this._context.http.graphql(
      GqlOperations.QUERY_ACCOUNT_BALANCE
    );
    return data.viewer?.savingsAccount?.currentSavingsBalance?.netAmount;
  }
```

getFeed de:
```typescript
  public async getFeed(): Promise<AccountTransaction[]> {
    const data = await this._context.http.graphql(
      GqlOperations.QUERY_ACCOUNT_FEED
    );
    return data?.viewer?.savingsAccount?.feed;
  }
```

para:

```typescript
  public async getFeed(): Promise<AccountTransaction[]> {
    const { data } = await this._context.http.graphql(
      GqlOperations.QUERY_ACCOUNT_FEED
    );
    return data?.viewer?.savingsAccount?.feed;
  }
```